### PR TITLE
Update link to docs to point to github.io domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       --><li><a href="#examples">examples</a> / </li><!--
       --><li><a href="#learning">learning</a> / </li><!--
       --><li><a href="#community">community</a> / </li><!--
-      --><li><a href="http://stack.gl/packages/">docs</a></li><!--
+      --><li><a href="http://stackgl.github.io/packages/">docs</a></li><!--
     --></ul>
     </nav>
 


### PR DESCRIPTION
This link was still pointing to the now no longer active stack.gl domain, breaking the site. With a small fix people are now again able to click through to the docs page.