### PR TITLE
Restore CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+stack.gl


### PR DESCRIPTION
It looks like the domain has been purchased again, but at least a few things have been migrated away from stack.gl in the mean time in order to fix broken links. Perhaps this should be restored?

/cc @dy @mikolalysenko 